### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/com/dougkeen/bart/activities/RoutesListActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/RoutesListActivity.java
@@ -66,6 +66,30 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
 
     private FavoritesArrayAdapter mRoutesAdapter;
 
+    private DragSortListView.DropListener onDrop = new DragSortListView.DropListener() {
+        @Override
+        public void drop(int from, int to) {
+            if (from == to)
+                return;
+
+            StationPair item = mRoutesAdapter.getItem(from);
+
+            mRoutesAdapter.move(item, to);
+            mRoutesAdapter.notifyDataSetChanged();
+        }
+    };
+
+    private DragSortListView.RemoveListener onRemove = new DragSortListView.RemoveListener() {
+        @Override
+        public void remove(int which) {
+            mRoutesAdapter.remove(mRoutesAdapter.getItem(which));
+            mRoutesAdapter.notifyDataSetChanged();
+        }
+    };
+
+    private MenuItem elevatorMenuItem;
+    private View origElevatorActionView;
+
     @App
     BartRunnerApplication app;
 
@@ -108,27 +132,6 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
 
         startContextualActionMode();
     }
-
-    private DragSortListView.DropListener onDrop = new DragSortListView.DropListener() {
-        @Override
-        public void drop(int from, int to) {
-            if (from == to)
-                return;
-
-            StationPair item = mRoutesAdapter.getItem(from);
-
-            mRoutesAdapter.move(item, to);
-            mRoutesAdapter.notifyDataSetChanged();
-        }
-    };
-
-    private DragSortListView.RemoveListener onRemove = new DragSortListView.RemoveListener() {
-        @Override
-        public void remove(int which) {
-            mRoutesAdapter.remove(mRoutesAdapter.getItem(which));
-            mRoutesAdapter.notifyDataSetChanged();
-        }
-    };
 
     @AfterViews
     void afterViews() {
@@ -278,9 +281,6 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
         inflater.inflate(R.menu.routes_list_menu, menu);
         return super.onCreateOptionsMenu(menu);
     }
-
-    private MenuItem elevatorMenuItem;
-    private View origElevatorActionView;
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/app/src/main/java/com/dougkeen/bart/activities/ViewDeparturesActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/ViewDeparturesActivity.java
@@ -73,6 +73,75 @@ public class ViewDeparturesActivity extends AppCompatActivity implements
 
     private boolean mBound = false;
 
+    private boolean mWasLongClick = false;
+
+    private YourTrainLayout mYourTrainSection;
+
+    private SwipeHelper mSwipeHelper;
+
+    private final ServiceConnection mConnection = new ServiceConnection() {
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            mEtdService = null;
+            mBound = false;
+        }
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            mEtdService = ((EtdServiceBinder) service).getService();
+            mBound = true;
+            if (getStationPair() != null) {
+                mEtdService
+                        .registerListener(ViewDeparturesActivity.this, false);
+            }
+        }
+    };
+
+    private final AdapterView.OnItemClickListener mListItemClickListener = new AdapterView.OnItemClickListener() {
+        @Override
+        public void onItemClick(AdapterView<?> adapterView, View view,
+                                int position, long id) {
+            if (mWasLongClick) {
+                mWasLongClick = false;
+                return;
+            }
+
+            if (mActionMode != null) {
+                /*
+                 * If action mode is displayed, cancel out of that
+                 */
+                mActionMode.finish();
+                getListView().clearChoices();
+            } else {
+                /*
+                 * Otherwise select the clicked departure as the one the user
+                 * wants to board
+                 */
+                setBoardedDeparture(
+                        getListAdapter().getItem(position), true);
+            }
+        }
+    };
+
+    private final AdapterView.OnItemLongClickListener mListItemLongClickListener = new AdapterView.OnItemLongClickListener() {
+        @Override
+        public boolean onItemLongClick(AdapterView<?> adapterView, View view,
+                                       int position, long id) {
+            mWasLongClick = true;
+            setSelectedDeparture(getListAdapter().getItem(position));
+            startDepartureActionMode();
+            return false;
+        }
+    };
+
+    private final View.OnClickListener mYourTrainSectionClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            ((Checkable) v).setChecked(true);
+            startYourTrainActionMode();
+        }
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -252,75 +321,6 @@ public class ViewDeparturesActivity extends AppCompatActivity implements
     private ListView getListView() {
         return (ListView) findViewById(android.R.id.list);
     }
-
-    private final ServiceConnection mConnection = new ServiceConnection() {
-        @Override
-        public void onServiceDisconnected(ComponentName name) {
-            mEtdService = null;
-            mBound = false;
-        }
-
-        @Override
-        public void onServiceConnected(ComponentName name, IBinder service) {
-            mEtdService = ((EtdServiceBinder) service).getService();
-            mBound = true;
-            if (getStationPair() != null) {
-                mEtdService
-                        .registerListener(ViewDeparturesActivity.this, false);
-            }
-        }
-    };
-
-    private boolean mWasLongClick = false;
-
-    private final AdapterView.OnItemClickListener mListItemClickListener = new AdapterView.OnItemClickListener() {
-        @Override
-        public void onItemClick(AdapterView<?> adapterView, View view,
-                                int position, long id) {
-            if (mWasLongClick) {
-                mWasLongClick = false;
-                return;
-            }
-
-            if (mActionMode != null) {
-                /*
-                 * If action mode is displayed, cancel out of that
-                 */
-                mActionMode.finish();
-                getListView().clearChoices();
-            } else {
-                /*
-                 * Otherwise select the clicked departure as the one the user
-                 * wants to board
-                 */
-                setBoardedDeparture(
-                        getListAdapter().getItem(position), true);
-            }
-        }
-    };
-
-    private final AdapterView.OnItemLongClickListener mListItemLongClickListener = new AdapterView.OnItemLongClickListener() {
-        @Override
-        public boolean onItemLongClick(AdapterView<?> adapterView, View view,
-                                       int position, long id) {
-            mWasLongClick = true;
-            setSelectedDeparture(getListAdapter().getItem(position));
-            startDepartureActionMode();
-            return false;
-        }
-    };
-
-    private final View.OnClickListener mYourTrainSectionClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View v) {
-            ((Checkable) v).setChecked(true);
-            startYourTrainActionMode();
-        }
-    };
-
-    private YourTrainLayout mYourTrainSection;
-
-    private SwipeHelper mSwipeHelper;
 
     protected DepartureArrayAdapter getListAdapter() {
         return mDeparturesAdapter;

--- a/app/src/main/java/com/dougkeen/bart/controls/Ticker.java
+++ b/app/src/main/java/com/dougkeen/bart/controls/Ticker.java
@@ -21,6 +21,12 @@ public class Ticker {
 
     private TickerEngine mEngine;
 
+    private Ticker() {
+        mSubscribers = new WeakHashMap<TickSubscriber, Object>();
+        mTickerHosts = new WeakHashMap<Context, Object>();
+        mEngine = new TickerEngine(this);
+    }
+
     private static class TickerEngine implements Runnable {
 
         private static final int TICK_INTERVAL_MILLIS = 1000;
@@ -92,12 +98,6 @@ public class Ticker {
             mSubscribers.put(subscriber, null);
             startTicking(host);
         }
-    }
-
-    private Ticker() {
-        mSubscribers = new WeakHashMap<TickSubscriber, Object>();
-        mTickerHosts = new WeakHashMap<Context, Object>();
-        mEngine = new TickerEngine(this);
     }
 
     public void startTicking(Context host) {

--- a/app/src/main/java/com/dougkeen/bart/controls/TimedTextSwitcher.java
+++ b/app/src/main/java/com/dougkeen/bart/controls/TimedTextSwitcher.java
@@ -12,6 +12,10 @@ import com.dougkeen.bart.model.TextProvider;
 
 public class TimedTextSwitcher extends TextSwitcher implements Ticker.TickSubscriber {
 
+    private int mTickInterval;
+    private TextProvider mTextProvider;
+    private CharSequence mLastText;
+
     public TimedTextSwitcher(Context context, AttributeSet attrs) {
         super(context, attrs);
         setInstanceVarsFromAttrs(attrs);
@@ -30,9 +34,6 @@ public class TimedTextSwitcher extends TextSwitcher implements Ticker.TickSubscr
         }
     }
 
-    private int mTickInterval;
-    private TextProvider mTextProvider;
-
     @Override
     public int getTickInterval() {
         return mTickInterval;
@@ -46,8 +47,6 @@ public class TimedTextSwitcher extends TextSwitcher implements Ticker.TickSubscr
         mTextProvider = textProvider;
         Ticker.getInstance().addSubscriber(this, getContext());
     }
-
-    private CharSequence mLastText;
 
     @Override
     public void setCurrentText(CharSequence text) {

--- a/app/src/main/java/com/dougkeen/bart/controls/YourTrainLayout.java
+++ b/app/src/main/java/com/dougkeen/bart/controls/YourTrainLayout.java
@@ -25,6 +25,35 @@ public class YourTrainLayout extends FrameLayout implements Checkable {
     private final CountdownTextView departureCountdown;
     private final CountdownTextView arrivalCountdown;
     private final TextView alarmText;
+    private boolean mChecked;
+    private Departure mDeparture;
+
+    private final Observer<Integer> mAlarmLeadObserver = new Observer<Integer>() {
+        @Override
+        public void onUpdate(Integer newValue) {
+            final Activity context = (Activity) getContext();
+            if (context != null) {
+                context.runOnUiThread(mUpdateAlarmIndicatorRunnable);
+            }
+        }
+    };
+
+    private final Observer<Boolean> mAlarmPendingObserver = new Observer<Boolean>() {
+        @Override
+        public void onUpdate(Boolean newValue) {
+            final Activity context = (Activity) getContext();
+            if (context != null) {
+                context.runOnUiThread(mUpdateAlarmIndicatorRunnable);
+            }
+        }
+    };
+
+    private final Runnable mUpdateAlarmIndicatorRunnable = new Runnable() {
+        @Override
+        public void run() {
+            updateAlarmIndicator();
+        }
+    };
 
     public YourTrainLayout(Context context) {
         this(context, null);
@@ -48,30 +77,6 @@ public class YourTrainLayout extends FrameLayout implements Checkable {
         arrivalCountdown = (CountdownTextView) findViewById(R.id.yourTrainArrivalCountdown);
         alarmText = (TextView) findViewById(R.id.alarmText);
     }
-
-    private boolean mChecked;
-
-    private Departure mDeparture;
-
-    private final Observer<Integer> mAlarmLeadObserver = new Observer<Integer>() {
-        @Override
-        public void onUpdate(Integer newValue) {
-            final Activity context = (Activity) getContext();
-            if (context != null) {
-                context.runOnUiThread(mUpdateAlarmIndicatorRunnable);
-            }
-        }
-    };
-
-    private final Observer<Boolean> mAlarmPendingObserver = new Observer<Boolean>() {
-        @Override
-        public void onUpdate(Boolean newValue) {
-            final Activity context = (Activity) getContext();
-            if (context != null) {
-                context.runOnUiThread(mUpdateAlarmIndicatorRunnable);
-            }
-        }
-    };
 
     @Override
     public boolean isChecked() {
@@ -166,11 +171,4 @@ public class YourTrainLayout extends FrameLayout implements Checkable {
             alarmText.setText(String.valueOf(mDeparture.getAlarmLeadTimeMinutes()));
         }
     }
-
-    private final Runnable mUpdateAlarmIndicatorRunnable = new Runnable() {
-        @Override
-        public void run() {
-            updateAlarmIndicator();
-        }
-    };
 }

--- a/app/src/main/java/com/dougkeen/bart/data/FavoritesArrayAdapter.java
+++ b/app/src/main/java/com/dougkeen/bart/data/FavoritesArrayAdapter.java
@@ -59,6 +59,14 @@ public class FavoritesArrayAdapter extends ArrayAdapter<StationPair> {
         }
     };
 
+    public FavoritesArrayAdapter(Context context, int textViewResourceId,
+                                 List<StationPair> objects) {
+        super(context, textViewResourceId, objects);
+        mHostActivity = (Activity) context;
+        mHostActivity.bindService(EtdService_.intent(mHostActivity).get(),
+                mConnection, Context.BIND_AUTO_CREATE);
+    }
+
     public void setUpEtdListeners() {
         if (mBound && mEtdService != null) {
             for (int i = getCount() - 1; i >= 0; i--) {
@@ -79,14 +87,6 @@ public class FavoritesArrayAdapter extends ArrayAdapter<StationPair> {
 
     public boolean areEtdListenersActive() {
         return !mEtdListeners.isEmpty();
-    }
-
-    public FavoritesArrayAdapter(Context context, int textViewResourceId,
-                                 List<StationPair> objects) {
-        super(context, textViewResourceId, objects);
-        mHostActivity = (Activity) context;
-        mHostActivity.bindService(EtdService_.intent(mHostActivity).get(),
-                mConnection, Context.BIND_AUTO_CREATE);
     }
 
     public void close() {

--- a/app/src/main/java/com/dougkeen/bart/data/RoutesColumns.java
+++ b/app/src/main/java/com/dougkeen/bart/data/RoutesColumns.java
@@ -7,16 +7,16 @@ public enum RoutesColumns {
             "AVE_TRIP_SAMPLE_COUNT", "INTEGER", true), AVERAGE_TRIP_LENGTH(
             "AVE_TRIP_LENGTH", "INTEGER", true);
 
+    public final String string;
+    public final String sqliteType;
+    public final Boolean nullable;
+
     // This class cannot be instantiated
     RoutesColumns(String string, String type, Boolean nullable) {
         this.string = string;
         this.sqliteType = type;
         this.nullable = nullable;
     }
-
-    public final String string;
-    public final String sqliteType;
-    public final Boolean nullable;
 
     protected String getColumnDef() {
         return string + " " + sqliteType + (nullable ? "" : " NOT NULL");

--- a/app/src/main/java/com/dougkeen/bart/model/Departure.java
+++ b/app/src/main/java/com/dougkeen/bart/model/Departure.java
@@ -31,26 +31,15 @@ public class Departure implements Parcelable, Comparable<Departure> {
 
     private static final DateFormat TIME_FORMAT = new SimpleDateFormat("h:mm");
 
-    public Departure() {
-        super();
-    }
+    public static final Parcelable.Creator<Departure> CREATOR = new Parcelable.Creator<Departure>() {
+        public Departure createFromParcel(Parcel in) {
+            return new Departure(in);
+        }
 
-    public Departure(String destinationAbbr, String destinationColor,
-                     String platform, String direction, boolean bikeAllowed,
-                     String trainLength, int minutes) {
-        super();
-        this.trainDestination = Station.getByAbbreviation(destinationAbbr);
-        this.destinationColor = destinationColor;
-        this.platform = platform;
-        this.direction = direction;
-        this.bikeAllowed = bikeAllowed;
-        this.trainLength = trainLength;
-        this.minutes = minutes;
-    }
-
-    public Departure(Parcel in) {
-        readFromParcel(in);
-    }
+        public Departure[] newArray(int size) {
+            return new Departure[size];
+        }
+    };
 
     private Station origin;
     private Station trainDestination;
@@ -83,6 +72,29 @@ public class Departure implements Parcelable, Comparable<Departure> {
     private boolean listedInETDs = true;
 
     private boolean selected;
+
+    private PendingIntent notificationIntent;
+
+    public Departure() {
+        super();
+    }
+
+    public Departure(String destinationAbbr, String destinationColor,
+                     String platform, String direction, boolean bikeAllowed,
+                     String trainLength, int minutes) {
+        super();
+        this.trainDestination = Station.getByAbbreviation(destinationAbbr);
+        this.destinationColor = destinationColor;
+        this.platform = platform;
+        this.direction = direction;
+        this.bikeAllowed = bikeAllowed;
+        this.trainLength = trainLength;
+        this.minutes = minutes;
+    }
+
+    public Departure(Parcel in) {
+        readFromParcel(in);
+    }
 
     public Station getOrigin() {
         return origin;
@@ -609,8 +621,6 @@ public class Departure implements Parcelable, Comparable<Departure> {
         this.alarmPending.setValue(false);
     }
 
-    private PendingIntent notificationIntent;
-
     private PendingIntent getNotificationIntent(Context context) {
         if (notificationIntent == null) {
             Intent targetIntent = new Intent(context,
@@ -732,16 +742,6 @@ public class Departure implements Parcelable, Comparable<Departure> {
         requiresTransfer = in.readByte() == (byte) 1;
         transferScheduled = in.readByte() == (byte) 1;
     }
-
-    public static final Parcelable.Creator<Departure> CREATOR = new Parcelable.Creator<Departure>() {
-        public Departure createFromParcel(Parcel in) {
-            return new Departure(in);
-        }
-
-        public Departure[] newArray(int size) {
-            return new Departure[size];
-        }
-    };
 
     public void notifyAlarmHasBeenHandled() {
         this.alarmPending.setValue(false);

--- a/app/src/main/java/com/dougkeen/bart/model/RealTimeDepartures.java
+++ b/app/src/main/java/com/dougkeen/bart/model/RealTimeDepartures.java
@@ -6,14 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 
 public class RealTimeDepartures {
-    public RealTimeDepartures(Station origin, Station destination,
-                              List<Route> routes) {
-        this.origin = origin;
-        this.destination = destination;
-        this.routes = routes;
-        this.unfilteredDepartures = new ArrayList<Departure>();
-    }
-
     private Station origin;
     private Station destination;
     private long time;
@@ -23,6 +15,13 @@ public class RealTimeDepartures {
     final private List<Departure> unfilteredDepartures;
 
     private List<Route> routes;
+
+    public RealTimeDepartures(Station origin, Station destination, List<Route> routes) {
+        this.origin = origin;
+        this.destination = destination;
+        this.routes = routes;
+        this.unfilteredDepartures = new ArrayList<Departure>();
+    }
 
     public Station getOrigin() {
         return origin;

--- a/app/src/main/java/com/dougkeen/bart/model/ScheduleInformation.java
+++ b/app/src/main/java/com/dougkeen/bart/model/ScheduleInformation.java
@@ -5,16 +5,18 @@ import java.util.List;
 
 public class ScheduleInformation {
 
+    private Station origin;
+    private Station destination;
+    private long date;
+    private List<ScheduleItem> trips;
+    private int aveTripLength = -1;
+    private int tripCount = 0;
+
     public ScheduleInformation(Station origin, Station destination) {
         super();
         this.origin = origin;
         this.destination = destination;
     }
-
-    private Station origin;
-    private Station destination;
-    private long date;
-    private List<ScheduleItem> trips;
 
     public Station getOrigin() {
         return origin;
@@ -61,9 +63,6 @@ public class ScheduleInformation {
         else
             return getTrips().get(getTrips().size() - 1).getDepartureTime();
     }
-
-    private int aveTripLength = -1;
-    private int tripCount = 0;
 
     public int getAverageTripLength() {
         if (aveTripLength < 0) {

--- a/app/src/main/java/com/dougkeen/bart/model/ScheduleItem.java
+++ b/app/src/main/java/com/dougkeen/bart/model/ScheduleItem.java
@@ -6,16 +6,6 @@ import java.util.Date;
 
 public class ScheduleItem {
 
-    public ScheduleItem() {
-        super();
-    }
-
-    public ScheduleItem(Station origin, Station destination) {
-        super();
-        this.origin = origin;
-        this.destination = destination;
-    }
-
     public static final int SCHEDULE_ITEM_DEPARTURE_EQUALS_TOLERANCE = 120000;
 
     private Station origin;
@@ -25,6 +15,16 @@ public class ScheduleItem {
     private long arrivalTime;
     private boolean bikesAllowed;
     private String trainHeadStation;
+
+    public ScheduleItem() {
+        super();
+    }
+
+    public ScheduleItem(Station origin, Station destination) {
+        super();
+        this.origin = origin;
+        this.destination = destination;
+    }
 
     public Station getOrigin() {
         return origin;

--- a/app/src/main/java/com/dougkeen/bart/model/StationPair.java
+++ b/app/src/main/java/com/dougkeen/bart/model/StationPair.java
@@ -12,6 +12,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StationPair implements Parcelable {
+    public static final Parcelable.Creator<StationPair> CREATOR = new Parcelable.Creator<StationPair>() {
+        public StationPair createFromParcel(Parcel in) {
+            return new StationPair(in);
+        }
+
+        public StationPair[] newArray(int size) {
+            return new StationPair[size];
+        }
+    };
+
+    private Station origin;
+    private Station destination;
+    private String fare;
+
+    private long fareLastUpdated;
+    private int averageTripLength;
+    private int averageTripSampleCount;
+
     @JsonCreator
     public StationPair(@JsonProperty("origin") Station origin,
                        @JsonProperty("destination") Station destination) {
@@ -39,14 +57,6 @@ public class StationPair implements Parcelable {
                 RoutesColumns.AVERAGE_TRIP_SAMPLE_COUNT);
         return pair;
     }
-
-    private Station origin;
-    private Station destination;
-    private String fare;
-
-    private long fareLastUpdated;
-    private int averageTripLength;
-    private int averageTripSampleCount;
 
     public Station getOrigin() {
         return origin;
@@ -145,14 +155,4 @@ public class StationPair implements Parcelable {
         origin = Station.getByAbbreviation(in.readString());
         destination = Station.getByAbbreviation(in.readString());
     }
-
-    public static final Parcelable.Creator<StationPair> CREATOR = new Parcelable.Creator<StationPair>() {
-        public StationPair createFromParcel(Parcel in) {
-            return new StationPair(in);
-        }
-
-        public StationPair[] newArray(int size) {
-            return new StationPair[size];
-        }
-    };
 }

--- a/app/src/main/java/com/dougkeen/bart/networktasks/EtdContentHandler.java
+++ b/app/src/main/java/com/dougkeen/bart/networktasks/EtdContentHandler.java
@@ -19,21 +19,11 @@ import com.dougkeen.bart.model.Route;
 import com.dougkeen.bart.model.Station;
 
 public class EtdContentHandler extends DefaultHandler {
-    public EtdContentHandler(Station origin, Station destination,
-                             List<Route> routes) {
-        super();
-        realTimeDepartures = new RealTimeDepartures(origin, destination, routes);
-    }
-
-    private final static List<String> TAGS = Arrays.asList("date", "time",
+    private static final List<String> TAGS = Arrays.asList("date", "time",
             "abbreviation", "minutes", "platform", "direction", "length",
             "color", "hexcolor", "bikeflag", "destination");
 
     private RealTimeDepartures realTimeDepartures;
-
-    public RealTimeDepartures getRealTimeDepartures() {
-        return realTimeDepartures;
-    }
 
     private String date;
     private String currentDestinationAbbreviation;
@@ -41,6 +31,16 @@ public class EtdContentHandler extends DefaultHandler {
     private String currentValue;
     private Departure currentDeparture;
     private boolean isParsingTag;
+
+    public EtdContentHandler(Station origin, Station destination,
+                             List<Route> routes) {
+        super();
+        realTimeDepartures = new RealTimeDepartures(origin, destination, routes);
+    }
+
+    public RealTimeDepartures getRealTimeDepartures() {
+        return realTimeDepartures;
+    }
 
     @Override
     public void characters(char[] ch, int start, int length)

--- a/app/src/main/java/com/dougkeen/bart/networktasks/FareContentHandler.java
+++ b/app/src/main/java/com/dougkeen/bart/networktasks/FareContentHandler.java
@@ -5,13 +5,13 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 public class FareContentHandler extends DefaultHandler {
-    public FareContentHandler() {
-        super();
-    }
-
     private String currentValue;
     private boolean isParsingTag;
     private String fare;
+
+    public FareContentHandler() {
+        super();
+    }
 
     public String getFare() {
         return fare;

--- a/app/src/main/java/com/dougkeen/bart/networktasks/GetRouteFareTask.java
+++ b/app/src/main/java/com/dougkeen/bart/networktasks/GetRouteFareTask.java
@@ -19,11 +19,11 @@ import java.net.MalformedURLException;
 public abstract class GetRouteFareTask extends
         AsyncTask<GetRouteFareTask.Params, Integer, String> {
 
-    private final static int MAX_ATTEMPTS = 5;
-    private final static String FARE_URL = "http://api.bart.gov/api/sched.aspx?cmd=fare&date=today&key="
+    private static final int MAX_ATTEMPTS = 5;
+    private static final String FARE_URL = "http://api.bart.gov/api/sched.aspx?cmd=fare&date=today&key="
             + Constants.API_KEY + "&orig=%1$s&dest=%2$s";
 
-    private final static OkHttpClient client = NetworkUtils.makeHttpClient();
+    private static final OkHttpClient client = NetworkUtils.makeHttpClient();
 
     private Exception mException;
 
@@ -93,14 +93,14 @@ public abstract class GetRouteFareTask extends
     }
 
     public static class Params {
+        public final Station origin;
+        public final Station destination;
+
         public Params(Station origin, Station destination) {
             super();
             this.origin = origin;
             this.destination = destination;
         }
-
-        public final Station origin;
-        public final Station destination;
     }
 
     @Override

--- a/app/src/main/java/com/dougkeen/bart/networktasks/NetworkUtils.java
+++ b/app/src/main/java/com/dougkeen/bart/networktasks/NetworkUtils.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 public class NetworkUtils {
+    static final int CONNECTION_TIMEOUT_MILLIS = 10000;
 
     private static class RetryInterceptor implements Interceptor {
         private static final String TAG = "RetryInterceptor";
@@ -42,6 +43,4 @@ public class NetworkUtils {
         client.interceptors().add(new RetryInterceptor());
         return client;
     }
-
-    static final int CONNECTION_TIMEOUT_MILLIS = 10000;
 }

--- a/app/src/main/java/com/dougkeen/bart/networktasks/ScheduleContentHandler.java
+++ b/app/src/main/java/com/dougkeen/bart/networktasks/ScheduleContentHandler.java
@@ -19,19 +19,24 @@ import com.dougkeen.bart.model.ScheduleItem;
 import com.dougkeen.bart.model.Station;
 
 public class ScheduleContentHandler extends DefaultHandler {
-    public ScheduleContentHandler(Station origin, Station destination) {
-        super();
-        schedule = new ScheduleInformation(origin, destination);
-    }
-
-    private final static List<String> TAGS = Arrays.asList("date", "time",
+    private static final List<String> TAGS = Arrays.asList("date", "time",
             "trip", "leg");
 
-    private final static DateFormat TRIP_DATE_FORMAT;
-    private final static DateFormat REQUEST_DATE_FORMAT;
+    private static final DateFormat TRIP_DATE_FORMAT;
+    private static final DateFormat REQUEST_DATE_FORMAT;
 
-    private final static TimeZone PACIFIC_TIME = TimeZone
+    private static final TimeZone PACIFIC_TIME = TimeZone
             .getTimeZone("America/Los_Angeles");
+
+    private ScheduleInformation schedule;
+
+    private String currentValue;
+    private boolean isParsingTag;
+
+    private String requestDate;
+    private String requestTime;
+
+    private ScheduleItem currentTrip;
 
     static {
         TRIP_DATE_FORMAT = new SimpleDateFormat("MM/dd/yyyy h:mm a");
@@ -41,19 +46,14 @@ public class ScheduleContentHandler extends DefaultHandler {
         REQUEST_DATE_FORMAT.setTimeZone(PACIFIC_TIME);
     }
 
-    private ScheduleInformation schedule;
+    public ScheduleContentHandler(Station origin, Station destination) {
+        super();
+        schedule = new ScheduleInformation(origin, destination);
+    }
 
     public ScheduleInformation getSchedule() {
         return schedule;
     }
-
-    private String currentValue;
-    private boolean isParsingTag;
-
-    private String requestDate;
-    private String requestTime;
-
-    private ScheduleItem currentTrip;
 
     @Override
     public void characters(char[] ch, int start, int length)

--- a/app/src/main/java/com/dougkeen/bart/services/EtdService.java
+++ b/app/src/main/java/com/dougkeen/bart/services/EtdService.java
@@ -36,6 +36,8 @@ public class EtdService extends Service {
 
     private Map<StationPair, EtdServiceEngine> mServiceEngineMap;
 
+    private long mNextFetchClockTime = 0;
+
     public EtdService() {
         super();
         mBinder = new EtdServiceBinder();
@@ -553,8 +555,6 @@ public class EtdService extends Service {
                 applyScheduleInformation(mLatestScheduleInfo);
             }
         }
-
-        private long mNextFetchClockTime = 0;
 
         private void scheduleDepartureFetch(int millisUntilExecute) {
             mPendingEtdRequest = true;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
George Kankava
