### PR TITLE
Return to route list after app has been backgrounded for 3+ hours

### DIFF
--- a/app/src/main/java/com/dougkeen/bart/BartRunnerApplication.java
+++ b/app/src/main/java/com/dougkeen/bart/BartRunnerApplication.java
@@ -9,10 +9,13 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
+import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.Application;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.media.MediaPlayer;
+import android.os.Bundle;
 import android.os.Parcel;
 import android.util.Log;
 
@@ -26,10 +29,14 @@ import com.googlecode.androidannotations.annotations.Bean;
 import com.googlecode.androidannotations.annotations.EApplication;
 
 @EApplication
-public class BartRunnerApplication extends Application {
+public class BartRunnerApplication extends Application implements
+        Application.ActivityLifecycleCallbacks {
+
     private static final int FIVE_MINUTES = 5 * 60 * 1000;
 
     private static final String CACHE_FILE_NAME = "lastBoardedDeparture";
+    private static final String PREFS_NAME = "prefs_bart_runner";
+    private static final String PREFS_ACTIVITY_TIMESTAMP = "prefs_activity_timestamp";
 
     private Departure mBoardedDeparture;
 
@@ -38,6 +45,8 @@ public class BartRunnerApplication extends Application {
     private boolean mAlarmSounding;
 
     private MediaPlayer mAlarmMediaPlayer;
+
+    private SharedPreferences mApplicationPreferences;
 
     private static Context context;
 
@@ -92,6 +101,8 @@ public class BartRunnerApplication extends Application {
     public void onCreate() {
         super.onCreate();
         context = getApplicationContext();
+        mApplicationPreferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        registerActivityLifecycleCallbacks(this);
     }
 
     public static Context getAppContext() {
@@ -221,5 +232,47 @@ public class BartRunnerApplication extends Application {
 
     public void setAlarmMediaPlayer(MediaPlayer alarmMediaPlayer) {
         this.mAlarmMediaPlayer = alarmMediaPlayer;
+    }
+
+    public void setActivityTimestamp(long timestamp) {
+        mApplicationPreferences.edit().putLong(PREFS_ACTIVITY_TIMESTAMP, timestamp).apply();
+    }
+
+    public long getActivityTimestamp() {
+        return mApplicationPreferences.getLong(PREFS_ACTIVITY_TIMESTAMP, 0L);
+    }
+
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        setActivityTimestamp(System.currentTimeMillis());
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+
     }
 }

--- a/app/src/main/java/com/dougkeen/bart/activities/AbstractViewActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/AbstractViewActivity.java
@@ -1,0 +1,24 @@
+package com.dougkeen.bart.activities;
+
+import android.support.v7.app.AppCompatActivity;
+
+import com.dougkeen.bart.BartRunnerApplication;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractViewActivity extends AppCompatActivity {
+
+    private static final int MAXIMUM_IDLE_HOURS = 3;
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        BartRunnerApplication application = (BartRunnerApplication) getApplication();
+        long lastActivity = application.getActivityTimestamp();
+        long currentTime = System.currentTimeMillis();
+        long timeDifference = currentTime - lastActivity;
+        if (TimeUnit.MILLISECONDS.toHours(timeDifference) >= MAXIMUM_IDLE_HOURS) {
+            finish();
+        }
+    }
+}

--- a/app/src/main/java/com/dougkeen/bart/activities/ViewDeparturesActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/ViewDeparturesActivity.java
@@ -53,7 +53,7 @@ import com.dougkeen.util.Assert;
 import com.dougkeen.util.Observer;
 import com.dougkeen.util.WakeLocker;
 
-public class ViewDeparturesActivity extends AppCompatActivity implements
+public class ViewDeparturesActivity extends AbstractViewActivity implements
         EtdServiceListener {
 
     private StationPair mStationPair;

--- a/app/src/main/java/com/dougkeen/bart/activities/ViewMapActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/ViewMapActivity.java
@@ -13,7 +13,7 @@ import com.dougkeen.bart.R;
 import com.dougkeen.util.Assert;
 
 
-public class ViewMapActivity extends AppCompatActivity {
+public class ViewMapActivity extends AbstractViewActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         // Used for annotation processing needed by the AndroidAnnotations library
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.6'
     }


### PR DESCRIPTION
@dougkeen 
When returning to the app after a prolonged period of time, the app is still on the last page viewed, which is usually the departures page. I've screwed up my schedule a few too many times by opening up the app and inadvertently assuming that the departure times I'm looking at are correct, when they're actually for the opposite route from this morning or yesterday evening.   

This is a change to return the user to the routes list page when returning to the app after three hours. I chose three hours semi-arbitrarily, but it feels long enough that there would be the expectation that the user would be returning to the app to look up a new route. 

--
I'm not sure if the way things currently work is intentional, but wanted to bring up this option!