### PR TITLE
Add snackbar when route deleted to undo action

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
 
     annotationProcessor "org.androidannotations:androidannotations:$AAVersion"
     implementation "org.androidannotations:androidannotations-api:$AAVersion"

--- a/app/src/main/java/com/dougkeen/bart/activities/RoutesListActivity.java
+++ b/app/src/main/java/com/dougkeen/bart/activities/RoutesListActivity.java
@@ -3,6 +3,8 @@ package com.dougkeen.bart.activities;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.view.MenuItemCompat;
@@ -85,6 +87,9 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
     @ViewById(R.id.alertMessages)
     TextView alertMessages;
 
+    @ViewById(R.id.coordinatorLayout)
+    CoordinatorLayout coordinatorLayout;
+
     @Click(R.id.quickLookupButton)
     void quickLookupButtonClick() {
         DialogFragment dialog = new QuickRouteDialogFragment();
@@ -125,9 +130,11 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
 
     private DragSortListView.RemoveListener onRemove = new DragSortListView.RemoveListener() {
         @Override
-        public void remove(int which) {
-            mRoutesAdapter.remove(mRoutesAdapter.getItem(which));
+        public void remove(final int which) {
+            final StationPair stationPair = mRoutesAdapter.getItem(which);
+            mRoutesAdapter.remove(stationPair);
             mRoutesAdapter.notifyDataSetChanged();
+            showRouteDeletedSnackbar(which, stationPair);
         }
     };
 
@@ -383,6 +390,18 @@ public class RoutesListActivity extends AppCompatActivity implements TickSubscri
         mActionMode.setTitle(mCurrentlySelectedStationPair.getOrigin().name);
         mActionMode.setSubtitle("to "
                 + mCurrentlySelectedStationPair.getDestination().name);
+    }
+
+    private void showRouteDeletedSnackbar(final int which, final StationPair stationPair) {
+        Snackbar.make(coordinatorLayout, R.string.snackbar_route_deleted, Snackbar.LENGTH_LONG)
+                .setAction(R.string.undo, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        mRoutesAdapter.insert(stationPair, which);
+                        mRoutesAdapter.notifyDataSetChanged();
+                    }
+                })
+                .show();
     }
 
     private final class RouteActionMode implements ActionMode.Callback {

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,59 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:gravity="center"
-    android:orientation="vertical">
-
-    <com.mobeta.android.dslv.DragSortListView
-        android:id="@android:id/list"
+    android:id="@+id/coordinatorLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="3dp"
-        android:layout_weight="1"
-        android:dividerHeight="1dp"
-        android:padding="3dp"
-        app:collapsed_height="1dp"
-        app:drag_enabled="true"
-        app:drag_handle_id="@id/dragHandle"
-        app:drag_scroll_start="0.33"
-        app:drag_start_mode="onDown"
-        app:float_alpha="0.6"
-        app:remove_enabled="true"
-        app:remove_mode="flingRemove"
-        app:slide_shuffle_speed="0.3" />
+        android:layout_height="fill_parent"
+        android:gravity="center"
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@android:id/empty"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:gravity="center_horizontal"
-        android:paddingTop="10sp"
-        android:text="@string/empty_favorites_list_message"
-        android:visibility="gone" />
-
-    <TextView
-        android:id="@+id/alertMessages"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:drawableLeft="@drawable/ic_warn"
-        android:visibility="gone" />
-
-    <FrameLayout
-        style="ButtonBar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom">
-
-        <Button
-            android:id="@+id/quickLookupButton"
+        <com.mobeta.android.dslv.DragSortListView
+            android:id="@android:id/list"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="@string/quick_departure_lookup" />
-    </FrameLayout>
+            android:layout_margin="3dp"
+            android:layout_weight="1"
+            android:dividerHeight="1dp"
+            android:padding="3dp"
+            app:collapsed_height="1dp"
+            app:drag_enabled="true"
+            app:drag_handle_id="@id/dragHandle"
+            app:drag_scroll_start="0.33"
+            app:drag_start_mode="onDown"
+            app:float_alpha="0.6"
+            app:remove_enabled="true"
+            app:remove_mode="flingRemove"
+            app:slide_shuffle_speed="0.3" />
 
-</LinearLayout>
+        <TextView
+            android:id="@android:id/empty"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:paddingTop="10sp"
+            android:text="@string/empty_favorites_list_message"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/alertMessages"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawableLeft="@drawable/ic_warn"
+            android:visibility="gone" />
+
+        <FrameLayout
+            style="ButtonBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom">
+
+            <Button
+                android:id="@+id/quickLookupButton"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/quick_departure_lookup" />
+        </FrameLayout>
+
+    </LinearLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,5 +50,6 @@
     <string name="minutes_before_departure">minutes before departure</string>
     <string name="notification_channel_id">BART_Runner_notifications</string>
     <string name="notification_channel_name">BART Runner departure notifications</string>
-
+    <string name="snackbar_route_deleted">Route deleted.</string>
+    <string name="undo">Undo</string>
 </resources>


### PR DESCRIPTION
Use the design support library to show a snackbar with an undo action

I'm not a big fan of how the snackbar blends into the rest of the UI since both are dark themed, but the Snackbar class doesn't have a way to simple way of changing the theme of the widget. I could manually hack the colors of the background and text color if needed.

![undo](https://user-images.githubusercontent.com/361209/46788116-6135d200-ccee-11e8-9e87-d65135cfaff8.gif)
